### PR TITLE
ReadChar in command-line feeds from the buffered input reader

### DIFF
--- a/src/rars/util/SystemIO.java
+++ b/src/rars/util/SystemIO.java
@@ -199,8 +199,17 @@ public class SystemIO {
     public static int readChar(int serviceNumber) throws CancelException {
         int returnValue;
 
-        // Need a popup?
-        if (Globals.getGui() != null && Globals.getSettings().getBooleanSetting(Settings.Bool.POPUP_SYSCALL_INPUT)) {
+        if (Globals.getGui() == null) {
+            try {
+                //Read the next char from the buffered input reader
+                returnValue = getInputReader().read();
+                if (returnValue == -1)
+                    returnValue = EOF;
+            } catch (IOException e) {
+                returnValue = EOF;
+            }
+        } else if (Globals.getSettings().getBooleanSetting(Settings.Bool.POPUP_SYSCALL_INPUT)) {
+            // Need a popup?
             String input = readStringInternal("0", "Enter a character value (syscall " + serviceNumber + ")", 1);
             if (input.length()>0)
                 returnValue = input.getBytes(StandardCharsets.UTF_8) [0] & 0xFF; // truncate

--- a/test/readintchar.s
+++ b/test/readintchar.s
@@ -1,0 +1,12 @@
+li a7, 5 # ReadInt
+ecall
+li a7, 1 # PrintInt
+ecall
+li a7, 12 # ReadChar
+ecall
+li a7, 11 # PrintChar
+ecall
+li a7, 10 # Exit
+ecall
+#stdin:42\n*
+#stdout:42*


### PR DESCRIPTION
Using the read system call cause buffering issue since characters might be in the buffer, so no more available.