### PR TITLE
Tests: force utf8

### DIFF
--- a/src/rars/api/Program.java
+++ b/src/rars/api/Program.java
@@ -8,6 +8,7 @@ import rars.util.SystemIO;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 
 /**
@@ -203,14 +204,22 @@ public class Program {
      * @return converts the bytes sent to stdout into a string (resets to "" when setup is called)
      */
     public String getSTDOUT(){
-        return stdout.toString();
+        try {
+            return stdout.toString("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
      * @return converts the bytes sent to stderr into a string (resets to "" when setup is called)
      */
     public String getSTDERR(){
-        return stderr.toString();
+        try {
+            return stderr.toString("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/test/RarsTest.java
+++ b/test/RarsTest.java
@@ -101,7 +101,7 @@ public class RarsTest {
         // This is just a temporary solution that should work for the tests I want to write
         p.getOptions().selfModifyingCode = false;
         try {
-            BufferedReader br = new BufferedReader(new FileReader(path));
+            BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(path), "UTF-8"));
             String line = br.readLine();
             while(line != null){
                 if (line.startsWith("#error on lines:")) {


### PR DESCRIPTION
This should helps on systems that do not use UTF-8 as Java default encoding