### PR TITLE
Fix 32 bit mode reading long in readInt syscall

### DIFF
--- a/src/rars/riscv/syscalls/SyscallReadInt.java
+++ b/src/rars/riscv/syscalls/SyscallReadInt.java
@@ -1,6 +1,7 @@
 package rars.riscv.syscalls;
 
 import rars.*;
+import rars.riscv.InstructionSet;
 import rars.riscv.AbstractSyscall;
 import rars.riscv.hardware.RegisterFile;
 import rars.util.SystemIO;
@@ -12,7 +13,11 @@ public class SyscallReadInt extends AbstractSyscall {
 
     public void simulate(ProgramStatement statement) throws SimulationException {
         try {
-            RegisterFile.updateRegister("a0", SystemIO.readInteger(this.getNumber()));
+            if (InstructionSet.rv64) {
+                RegisterFile.updateRegister("a0", SystemIO.readLong(this.getNumber()));
+            } else {
+                RegisterFile.updateRegister("a0", SystemIO.readInteger(this.getNumber()));
+            }
         } catch (NumberFormatException e) {
             if (e.getMessage().equals("Cancel"))
                 throw new CancelException();

--- a/src/rars/util/SystemIO.java
+++ b/src/rars/util/SystemIO.java
@@ -64,7 +64,14 @@ public class SystemIO {
      * @return int value corresponding to user input
      */
 
-    public static long readInteger(int serviceNumber) throws CancelException {
+    public static int readInteger(int serviceNumber) throws CancelException {
+        String input = readStringInternal("0", "Enter an integer value (syscall " + serviceNumber + ")", -1);
+        // Client is responsible for catching NumberFormatException
+        if (input == null) throw new CancelException();
+        return Integer.parseInt(input.trim());
+    }
+
+    public static long readLong(int serviceNumber) throws CancelException {
         String input = readStringInternal("0", "Enter an integer value (syscall " + serviceNumber + ")", -1);
         // Client is responsible for catching NumberFormatException
         if (input == null) throw new CancelException();


### PR DESCRIPTION
Fixes #93

Let me know if you'd rather have the `readLong`/`readInt` deduplicated, or fixed in another way.

Tested with the given reproduction case in the issue:

```
li a7, 5
ecall
li a7, 1
ecall
mv a0, a0
ecall
```

Throws error on 32 bit, prints identical number twice on 64 as expected.