### PR TITLE
Add file filter to save dialog, remove acceptall option

### DIFF
--- a/src/rars/tools/AbstractToolAndApplication.java
+++ b/src/rars/tools/AbstractToolAndApplication.java
@@ -318,10 +318,8 @@ public abstract class AbstractToolAndApplication extends JFrame implements Tool,
                         if (mostRecentlyOpenedFile != null) {
                             fileChooser.setSelectedFile(mostRecentlyOpenedFile);
                         }
-                        // DPS 13 June 2007.  The next 4 lines add file filter to file chooser.
-                        FileFilter defaultFileFilter = FilenameFinder.getFileFilter(Globals.fileExtensions, "Assembler Files", true);
-                        fileChooser.addChoosableFileFilter(defaultFileFilter);
-                        fileChooser.addChoosableFileFilter(fileChooser.getAcceptAllFileFilter());
+
+                        FileFilter defaultFileFilter = FilenameFinder.getFileFilter(Globals.fileExtensions, "Assembly Files", true);
                         fileChooser.setFileFilter(defaultFileFilter);
 
                         if (fileChooser.showOpenDialog(that) == JFileChooser.APPROVE_OPTION) {
@@ -695,7 +693,7 @@ public abstract class AbstractToolAndApplication extends JFrame implements Tool,
             rars.Globals.program = program; // Shouldn't have to do this...
             String fileToAssemble = mostRecentlyOpenedFile.getPath();
             ArrayList<String> filesToAssemble;
-            if (multiFileAssemble) {// setting (check box in file open dialog) calls for multiple file assembly 
+            if (multiFileAssemble) {// setting (check box in file open dialog) calls for multiple file assembly
                 filesToAssemble = FilenameFinder.getFilenameList(
                         new File(fileToAssemble).getParent(), Globals.fileExtensions);
             } else {

--- a/src/rars/venus/EditTabbedPane.java
+++ b/src/rars/venus/EditTabbedPane.java
@@ -329,6 +329,9 @@ public class EditTabbedPane extends JTabbedPane {
                 // end of 13-July-2011 code.
                 saveDialog.setDialogTitle("Save As");
 
+                FileFilter defaultFileFilter = FilenameFinder.getFileFilter(Globals.fileExtensions, "Assembly Files", true);
+                saveDialog.setFileFilter(defaultFileFilter);
+
                 int decision = saveDialog.showSaveDialog(mainUI);
                 if (decision != JFileChooser.APPROVE_OPTION) {
                     return null;
@@ -354,7 +357,7 @@ public class EditTabbedPane extends JTabbedPane {
                     }
                 }
             }
-            // Either file with selected name does not exist or user wants to 
+            // Either file with selected name does not exist or user wants to
             // overwrite it, so go for it!
             try {
                 BufferedWriter outFileStream = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(theFile), "UTF-8"));
@@ -562,7 +565,7 @@ public class EditTabbedPane extends JTabbedPane {
             }
             return true;
         }
-      
+
        /*
         * Open the specified file.  Return true if file opened, false otherwise
         */


### PR DESCRIPTION
Also renames "Assembler" files to "Assembly" files in the dialog.

Not entirely sure what you meant by the file type choice not being the default - it seemed to work fine for me. Maybe a windows thing, not sure as I am on Linux.

Regardless, I removed the "acceptAll" / (*) part which I assume is what you want on windows. Otherwise, please do let me know and I'll change it.

Fixes #38 