### PR TITLE
Set column minimum width, rather than max

### DIFF
--- a/src/rars/venus/TextSegmentWindow.java
+++ b/src/rars/venus/TextSegmentWindow.java
@@ -108,9 +108,9 @@ public class TextSegmentWindow extends JInternalFrame implements Observer {
                 ScrollPaneConstants.HORIZONTAL_SCROLLBAR_ALWAYS);
         contentPane.add(tableScroller);
 
-        setColumnMaxWidth(table.getColumnModel().getColumn(BREAK_COLUMN), columnNames[0]);
-        setColumnMaxWidth(table.getColumnModel().getColumn(ADDRESS_COLUMN), "0x00000000");
-        setColumnMaxWidth(table.getColumnModel().getColumn(CODE_COLUMN), "0x00000000");
+        setColumnMinWidth(table.getColumnModel().getColumn(BREAK_COLUMN), columnNames[0]);
+        setColumnMinWidth(table.getColumnModel().getColumn(ADDRESS_COLUMN), "0x00000000");
+        setColumnMinWidth(table.getColumnModel().getColumn(CODE_COLUMN), "0x00000000");
         table.getColumnModel().getColumn(BASIC_COLUMN).setPreferredWidth(160);
         table.getColumnModel().getColumn(SOURCE_COLUMN).setPreferredWidth(280);
 
@@ -180,14 +180,11 @@ public class TextSegmentWindow extends JInternalFrame implements Observer {
         return maxSourceLineNumber;
     }
 
-    /**
-     *
-     */
-    public void setColumnMaxWidth(TableColumn column, String referenceText) {
+    public void setColumnMinWidth(TableColumn column, String referenceText) {
         Component component = this; // column.getCellRenderer().getTableCellRendererComponent();
         FontMetrics fontMetrics = component.getFontMetrics(component.getFont());
         int width = fontMetrics.stringWidth(referenceText) + 10;
-        column.setMaxWidth(width);
+        column.setMinWidth(width);
         column.setPreferredWidth(width);
     }
 
@@ -733,7 +730,7 @@ public class TextSegmentWindow extends JInternalFrame implements Observer {
                     Globals.memory.setRawWord(address, val);
                 }
                 // somehow, user was able to display out-of-range address.  Most likely to occur between
-                // stack base and Kernel.  
+                // stack base and Kernel.
                 catch (AddressErrorException aee) {
                     return;
                 }
@@ -837,8 +834,8 @@ public class TextSegmentWindow extends JInternalFrame implements Observer {
             return cell;
         }
     }
-      
-   
+
+
    /*
    * Cell renderer for Breakpoint column.  We can use this to enable/disable breakpoint checkboxes with
    * a single action.  This class blatantly copied/pasted from


### PR DESCRIPTION
Fixes #94 

This regression was introduced with https://github.com/rarsm/rars/commit/c1def93d8f7e9d345e9b65dcaafa2b3a04d1fa9b

I think the UI didn't like the max being so small, another fix could've been just adding more padding. But I think it's a simpler fix to have the minimum width set instead of forcing it to be smaller which some users might also not like. Or maybe that was what was intended all along.

Once again, let me know if you'd like this resolved another way