### PR TITLE
Fix "call" pseudo instruction that uselessly modified register "t1"

### DIFF
--- a/src/PseudoOps.txt
+++ b/src/PseudoOps.txt
@@ -111,7 +111,7 @@ jr t0, -100     ;jalr x0, RG1, VL2 ;#Jump Register: Jump to address in t0
 jalr t0, -100   ;jalr x1, RG1, VL2 ;#Jump And Link Register: Jump to address in t0 and set the return address to ra
 jalr t0,-100(t1);jalr RG1, RG4, VL2;#Jump And Link Register: Jump to address in t1 and set the return address to t0
 ret             ;jalr x0, x1, 0    ;#Return: return from a subroutine
-call label      ;auipc x6,PCH1     ;jalr x1, x6, PCL1;#CALL: call a far-away subroutine
+call label      ;auipc x1,PCH1     ;jalr x1, x1, PCL1;#CALL: call a far-away subroutine
 tail label      ;auipc x6,PCH1     ;jalr x0, x6, PCL1;#TAIL call: tail call (call without saving return address)a far-away subroutine
 
 #########################  load/store pseudo-ops start here  ##########################


### PR DESCRIPTION
The assembler translates `call label` as a `auipc` / `jalr` pair:

```
auipc x6,imm1
jalr  x1,x6,imm2
```

It uses register `x6` (`t1`) to do so while register `x1` (`ra`) is available and must indeed be modified anyway to store the return address. Although the ILP32 Application Binary Interface (ABI) and other ABIs consider `x6` as non-saved, I do not see any reason to enforce an ABI in RARS more than strictly needed. So, I suggest to translate `call label` as:

```
auipc x1,imm1
jalr  x1,x1,imm2
```

Note: one could claim that this is still ABI-related because we use `x1` (`ra`). But using a register is unavoidable if one wants a `call` pseudo-instruction. Choosing `x1` makes sense as it is the preferred register for this purpose in ILP32 and alike.

Note: another pseudo-instruction (and only one) also silently modifies a non-saved register: `tail label`. As its target register is `x0` we cannot fix it as we did for `call`. My intuition is that `tail` shall be removed completely but this breaks backward compatibility. We should maybe add a warning in its brief description?