### PR TITLE
Syscall typo fix

### DIFF
--- a/src/help/SyscallHelpPrelude.html
+++ b/src/help/SyscallHelpPrelude.html
@@ -19,8 +19,8 @@ Step 4. Retrieve return values, if any, from result registers as specified.<br>
 </p>
 <strong>Example: display the value stored in $t0 on the console</strong><br>
 <pre>
-    li  a7, 1          # service 1 is print integer
-    add a0, t0, zero   # load desired value into argument register a0, using pseudo-op
+    li a7, 1          # service 1 is print integer
+    mv a0, t0         # load desired value into argument register a0, using pseudo-op
     ecall
 </pre>
 <h3>Table of Available Services</h3>


### PR DESCRIPTION
Followed @privat's suggestion and fixed the typo in the syscall prelude help file.

closes #97
