### PR TITLE
Toggle register number visibility

### DIFF
--- a/src/rars/Settings.java
+++ b/src/rars/Settings.java
@@ -134,7 +134,11 @@ public class Settings extends Observable {
         /**
          * Flag to determine whether rars is in dark mode instead of light mode.
          */
-        DARK_MODE_ENABLED("DarkModeEnabled", false);
+        DARK_MODE_ENABLED("DarkModeEnabled", false),
+        /**
+         * Flag to determine whether or not the register numbers are displayed.
+         */
+        DISPLAY_REGISTER_NUMBERS("DisplayRegisterNumbers", true);
 
         // TODO: add option for turning off user trap handling and interrupts
         private String name;

--- a/src/rars/venus/VenusUI.java
+++ b/src/rars/venus/VenusUI.java
@@ -60,7 +60,8 @@ public class VenusUI extends JFrame {
     private JMenuItem runGo, runStep, runBackstep, runReset, runAssemble, runStop, runPause, runClearBreakpoints, runToggleBreakpoints;
     private JCheckBoxMenuItem settingsLabel, settingsValueDisplayBase, settingsAddressDisplayBase,
             settingsExtended, settingsAssembleOnOpen, settingsAssembleAll, settingsAssembleOpen, settingsWarningsAreErrors,
-            settingsStartAtMain, settingsSelfModifyingCode, settingsRV64, settingsDeriveCurrentWorkingDirectory, settingsDarkMode;
+            settingsStartAtMain, settingsSelfModifyingCode, settingsRV64, settingsDeriveCurrentWorkingDirectory, settingsDarkMode, 
+            settingsDisplayRegisterNumbers;
     private JMenuItem settingsExceptionHandler, settingsEditor, settingsHighlighting, settingsMemoryConfiguration;
     private JMenuItem helpHelp, helpAbout;
 
@@ -616,6 +617,8 @@ public class VenusUI extends JFrame {
                 }
             }
         });
+        settingsDisplayRegisterNumbers = new JCheckBoxMenuItem(settingsDisplayRegisterNumbersAction);
+        settingsDisplayRegisterNumbers.setSelected(Globals.getSettings().getBooleanSetting(Settings.Bool.DISPLAY_REGISTER_NUMBERS));
         settingsAssembleOnOpen = new JCheckBoxMenuItem(settingsAssembleOnOpenAction);
         settingsAssembleOnOpen.setSelected(Globals.getSettings().getBooleanSetting(Settings.Bool.ASSEMBLE_ON_OPEN));
         settingsAssembleAll = new JCheckBoxMenuItem(settingsAssembleAllAction);
@@ -647,6 +650,7 @@ public class VenusUI extends JFrame {
         settings.add(settingsRV64);
         settings.addSeparator();
         settings.add(settingsDarkMode);
+        settings.add(settingsDisplayRegisterNumbers);
         settings.add(settingsEditor);
         settings.add(settingsHighlighting);
         settings.add(settingsExceptionHandler);

--- a/src/rars/venus/VenusUI.java
+++ b/src/rars/venus/VenusUI.java
@@ -86,7 +86,8 @@ public class VenusUI extends JFrame {
             settingsExtendedAction, settingsAssembleOnOpenAction, settingsAssembleOpenAction, settingsAssembleAllAction,
             settingsWarningsAreErrorsAction, settingsStartAtMainAction,
             settingsExceptionHandlerAction, settingsEditorAction, settingsHighlightingAction, settingsMemoryConfigurationAction,
-            settingsSelfModifyingCodeAction, settingsRV64Action, settingsDeriveCurrentWorkingDirectoryAction, settingsDarkModeAction;
+            settingsSelfModifyingCodeAction, settingsRV64Action, settingsDeriveCurrentWorkingDirectoryAction, settingsDarkModeAction,
+            settingsDisplayRegisterNumbersAction;
     private Action helpHelpAction, helpAboutAction;
 
 
@@ -441,6 +442,8 @@ public class VenusUI extends JFrame {
                     Settings.Bool.DERIVE_CURRENT_WORKING_DIRECTORY);
             settingsDarkModeAction = new SettingsAction("Dark mode", "If set, RARS will be in dark mode at the next opening. Uncheck for light mode",
                     Settings.Bool.DARK_MODE_ENABLED);
+            settingsDisplayRegisterNumbersAction = new SettingsAction("Display Register Numbers", "Toggle display of register numbers in the Registers Tab",
+                    Settings.Bool.DISPLAY_REGISTER_NUMBERS);
 
             settingsEditorAction = new SettingsEditorAction("Editor...", null,
                     "View and modify text editor settings.", null, null
@@ -456,6 +459,7 @@ public class VenusUI extends JFrame {
                     null, "View and modify memory segment base addresses for the simulated processor",
                     null, null
             );
+            
 
             helpHelpAction = new HelpHelpAction("Help", loadIcon("Help22.png"),
                     "Help", KeyEvent.VK_H, KeyStroke.getKeyStroke(KeyEvent.VK_F1, 0), mainUI);

--- a/src/rars/venus/registers/RegisterBlockWindow.java
+++ b/src/rars/venus/registers/RegisterBlockWindow.java
@@ -17,6 +17,8 @@ import javax.swing.event.TableModelEvent;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.JTableHeader;
+import javax.swing.table.TableColumn;
+
 import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.util.Arrays;
@@ -34,6 +36,7 @@ public abstract class RegisterBlockWindow extends JPanel implements Observer {
     private boolean highlighting;
     private RegistersAccessNotice stepAccessNotices;    //contains the register access notices for the current step
     private Register[] registers;
+    private TableColumn numberColumn;
 
     private static final int NAME_COLUMN = 0;
     private static final int NUMBER_COLUMN = 1;
@@ -67,6 +70,11 @@ public abstract class RegisterBlockWindow extends JPanel implements Observer {
         table.setPreferredScrollableViewportSize(new Dimension(200, 700));
         this.setLayout(new BorderLayout());  // table display will occupy entire width if widened
         this.add(new JScrollPane(table, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED));
+
+        // Copy numbers column
+        numberColumn = table.getColumnModel().getColumn(NUMBER_COLUMN);
+        // Hide number column if user preference is to not display them
+        updateNumbersColumn();
     }
 
     protected abstract String formatRegister(Register value, int base);
@@ -184,6 +192,7 @@ public abstract class RegisterBlockWindow extends JPanel implements Observer {
                 endObserving();
             }
         } else if (observable == settings) {
+            updateNumbersColumn();
             updateRowHeight();
         } else if (obj instanceof RegisterAccessNotice) {
             // NOTE: each register is a separate Observable
@@ -193,6 +202,20 @@ public abstract class RegisterBlockWindow extends JPanel implements Observer {
             this.highlighting = true;
             addRegisterHighlighting((Register) observable, access.getAccessType());
             Globals.getGui().getRegistersPane().setSelectedComponent(this);
+        }
+    }
+
+    /**
+     * Updates the width of the number column based on the user's preference.
+     * 
+     * Triggers on settings change.
+     */
+    private void updateNumbersColumn() {
+        if (!settings.getBooleanSetting(Settings.Bool.DISPLAY_REGISTER_NUMBERS)) {
+            table.getColumnModel().removeColumn(numberColumn);
+        } else if (table.getColumnModel().getColumn(NUMBER_COLUMN) != numberColumn) {
+            table.getColumnModel().addColumn(numberColumn);
+            table.getColumnModel().moveColumn(2, 1);
         }
     }
 


### PR DESCRIPTION
Added a setting option for allowing register numbers to be hidden to save space as requested in #91.

The option is currently located in the Settings menu.

Let me know if the position should change or if I can make the option easier to understand.

closes #91 