### PR TITLE
.include won't just inline files, but "project assemble" them as in the IDE

### DIFF
--- a/examples/bottles.s
+++ b/examples/bottles.s
@@ -1,3 +1,4 @@
+.include "printf.s"
 
 .globl  main
 .data

--- a/examples/printf.s
+++ b/examples/printf.s
@@ -1,5 +1,8 @@
+.include "printstr.s"
+.include "printnum.s"
+
 .globl printf
-.text
+#.text
 # input: a0 = template string, a1-a7=arguments in order for that template
 # no output
 printf:
@@ -29,14 +32,14 @@ printf:
 	mv s7, a7
 
 	# loop through the template until we hit a %
-loop:
+printf_loop:
 	lb t1, 0(t0)
-	beqz t1, done
+	beqz t1, printf_done
 	li t2, 0x25 # %
-	beq t1, t2, outputArg
+	beq t1, t2, printf_outputArg
 	addi t0, t0, 1
-	j loop
-outputArg:
+	j printf_loop
+printf_outputArg:
 
 	# Print out all of the characters we have interated over thus far
 	# Write (64) from a0-t0 to stdout (1)
@@ -51,28 +54,28 @@ outputArg:
 
 	lb t0, -1(s0)
 	li t1, 0x64 # 'd'
-	beq t0, t1,  outputNum
+	beq t0, t1,  printf_outputNum
 	li t1, 0x78 # 'x'
-	beq t0, t1, outputHex
+	beq t0, t1, printf_outputHex
 	li t1, 0x73 # 's'
-	beq t0, t1, outputStr
+	beq t0, t1, printf_outputStr
 	# Exit if the character following if not d or x
 	mv t0, s0
-	j done
-outputStr:
+	j printf_done
+printf_outputStr:
 	mv a0, s1
 	call printStr
-	j noOutput
-outputHex:
+	j printf_noOutput
+printf_outputHex:
 	mv a0, s1
 	call printHex
-	j noOutput
-outputNum:
+	j printf_noOutput
+printf_outputNum:
         mv a0, s1
         call printDec
 
 
-noOutput:
+printf_noOutput:
 	# Shift arguments down 
 	mv s1, s2
 	mv s2, s3
@@ -84,8 +87,8 @@ noOutput:
 	# Reinit t0	
 	mv t0, s0
 
-	j loop
-done:
+	j printf_loop
+printf_done:
 	# Print out the characters till the end
 	# Write (64) from the buffer to stdout (1)
         li a0, 1

--- a/examples/printnum.s
+++ b/examples/printnum.s
@@ -13,28 +13,28 @@ temp:
 printDec:
     	# t0 = abs(a0);
         mv t0, a0
-        bgez t0, positive
+        bgez t0, printnum_positive
 	xori t0, t0, -1
 	addi t0, t0, 1
-positive:      
+printnum_positive:      
 
         # convert t0 to digits in the buffer
         la a1, temp
         li t2, 10
-decLoop:
+printnum_decLoop:
         rem t3, t0, t2
         div t0, t0, t2 
         addi t3, t3, 0x30 # += '0'; converts a numerical 0-9 to the characters '0'-'9'
         addi a1, a1, -1
         sb t3, 0(a1)
-        bnez t0, decLoop
+        bnez t0, printnum_decLoop
         
         # Add a negative sign if it was negative
-        bgez a0, notNegative
+        bgez a0, printnum_notNegative
         li t3, 0x2D # '-'
         addi a1, a1, -1
         sb t3, 0(a1)
-notNegative:
+printnum_notNegative:
 	
 	# Write (64) from the temporary buffer to stdout (1) 
 	li a0, 1
@@ -49,16 +49,16 @@ printHex:
         # convert t0 to digits in the buffer
         la a1, temp
         li t2, 10
-hexLoop:
+printnum_hexLoop:
         andi t3, a0, 0xF
         srli a0, a0, 4 
-	blt t3, t2, offset
+	blt t3, t2, printnum_offset
 	addi t3, t3, 7 # += 'A' - '0' - 10; preps a numerical 10-15 to be converted to the characters 'A'-'F'
-offset:	
+printnum_offset:	
         addi t3, t3, 0x30 # += '0'; converts a numerical 0-9 to the characters '0'-'9'
         addi a1, a1, -1
 	sb t3, 0(a1)
-        bnez a0, hexLoop
+        bnez a0, printnum_hexLoop
 
 	# Add the 0x to the funct	
 	addi a1, a1, -2

--- a/examples/printstr.s
+++ b/examples/printstr.s
@@ -2,11 +2,11 @@
 .text
 printStr:
 	mv t0, a0
-	# loop until null byte
-loop:
+	# printStr_loop until null byte
+printStr_loop:
 	lb t1, 0(t0)
 	addi t0, t0, 1
-	bnez t1, loop
+	bnez t1, printStr_loop
 	
 	# Compute length
 	sub a2, t0, a0

--- a/examples/pwd.s
+++ b/examples/pwd.s
@@ -1,3 +1,5 @@
+.include "printstr.s"
+
 .globl main
 .data
 buf:

--- a/src/rars/RISCVprogram.java
+++ b/src/rars/RISCVprogram.java
@@ -5,9 +5,12 @@ import rars.riscv.hardware.RegisterFile;
 import rars.simulator.BackStepper;
 import rars.simulator.Simulator;
 
+import javax.xml.transform.Source;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Internal representations of the program.  Connects source, tokens and machine code.  Having
@@ -243,9 +246,9 @@ public class RISCVprogram {
      * @throws AssemblyException Will throw exception if errors occurred while tokenizing.
      **/
 
-    public void tokenize() throws AssemblyException {
+    public void tokenize(HashMap<String, ArrayList<SourceLine>> IncludedFiles) throws AssemblyException {
         this.tokenizer = new Tokenizer();
-        this.tokenList = tokenizer.tokenize(this);
+        this.tokenList = tokenizer.tokenize(this, IncludedFiles);
         this.localSymbolTable = new SymbolTable(this.filename); // prepare for assembly
     }
 
@@ -267,6 +270,7 @@ public class RISCVprogram {
 
     public ArrayList<RISCVprogram> prepareFilesForAssembly(ArrayList<String> filenames, String leadFilename, String exceptionHandler) throws AssemblyException {
         ArrayList<RISCVprogram> programsToAssemble = new ArrayList<>();
+        HashMap<String, ArrayList<SourceLine>> IncludedFiles = new HashMap<>();
         int leadFilePosition = 0;
         if (exceptionHandler != null && exceptionHandler.length() > 0) {
             filenames.add(0, exceptionHandler);
@@ -275,7 +279,7 @@ public class RISCVprogram {
         for (String filename : filenames) {
             RISCVprogram preparee = (filename.equals(leadFilename)) ? this : new RISCVprogram();
             preparee.readSource(filename);
-            preparee.tokenize();
+            preparee.tokenize(IncludedFiles);
             // I want "this" RISCVprogram to be the first in the list...except for exception handler
             if (preparee == this && programsToAssemble.size() > 0) {
                 programsToAssemble.add(leadFilePosition, preparee);
@@ -283,6 +287,17 @@ public class RISCVprogram {
                 programsToAssemble.add(preparee);
             }
         }
+        for (Map.Entry<String, ArrayList<SourceLine>> entry : IncludedFiles.entrySet()) {
+            String filename = entry.getKey();
+            boolean present = !programsToAssemble.stream()
+                    .noneMatch(p -> p.getFilename().equals(filename));
+            if (present) continue;
+            RISCVprogram preparee = new RISCVprogram();
+            preparee.readSource(filename);
+            preparee.tokenize(IncludedFiles);
+            programsToAssemble.add(preparee);
+        }
+
         return programsToAssemble;
     }
 

--- a/src/rars/api/Program.java
+++ b/src/rars/api/Program.java
@@ -1,6 +1,7 @@
 package rars.api;
 
 import rars.*;
+import rars.assembler.SourceLine;
 import rars.riscv.hardware.*;
 import rars.simulator.ProgramArgumentList;
 import rars.simulator.Simulator;
@@ -10,6 +11,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.HashMap;
 
 /**
  * <p>
@@ -103,7 +105,7 @@ public class Program {
     public ErrorList assembleString(String source) throws AssemblyException {
         ArrayList<RISCVprogram> programs = new ArrayList<>();
         code.fromString(source);
-        code.tokenize();
+        code.tokenize(new HashMap<String, ArrayList<SourceLine>>());
         programs.add(code);
         return assemble(programs);
     }

--- a/src/rars/assembler/Tokenizer.java
+++ b/src/rars/assembler/Tokenizer.java
@@ -2,6 +2,7 @@ package rars.assembler;
 
 import rars.*;
 
+import javax.xml.transform.Source;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -60,12 +61,12 @@ public class Tokenizer {
      * that represents a tokenized source statement from the program.
      **/
 
-    public ArrayList<TokenList> tokenize(RISCVprogram p) throws AssemblyException {
+    public ArrayList<TokenList> tokenize(RISCVprogram p, HashMap<String, ArrayList<SourceLine>> IncludedFiles) throws AssemblyException {
         sourceRISCVprogram = p;
         equivalents = new HashMap<>(); // DPS 11-July-2012
         ArrayList<TokenList> tokenList = new ArrayList<>();
         //ArrayList source = p.getSourceList();
-        ArrayList<SourceLine> source = processIncludes(p, new HashMap<>()); // DPS 9-Jan-2013
+        ArrayList<SourceLine> source = processIncludes(p, IncludedFiles); // DPS 9-Jan-2013
         p.setSourceLineList(source);
         TokenList currentLineTokens;
         String sourceLine;
@@ -96,9 +97,15 @@ public class Tokenizer {
     // files that themselves have .include.  Plus it will detect and report recursive
     // includes both direct and indirect.
     // DPS 11-Jan-2013
-    private ArrayList<SourceLine> processIncludes(RISCVprogram program, Map<String, String> inclFiles) throws AssemblyException {
+    private ArrayList<SourceLine> processIncludes(RISCVprogram program, Map<String, ArrayList<SourceLine>> inclFiles) throws AssemblyException {
         ArrayList<String> source = program.getSourceList();
         ArrayList<SourceLine> result = new ArrayList<>(source.size());
+        String filename = program.getFilename();
+        if (!inclFiles.containsKey(filename)) {
+            inclFiles.put(filename, result);
+        } else {
+            return inclFiles.get(filename);
+        }
         for (int i = 0; i < source.size(); i++) {
             String line = source.get(i);
             TokenList tl = tokenizeLine(program, i + 1, line, false);
@@ -107,12 +114,13 @@ public class Tokenizer {
                 if (tl.get(ii).getValue().equalsIgnoreCase(Directives.INCLUDE.getName())
                         && (tl.size() > ii + 1)
                         && tl.get(ii + 1).getType() == TokenTypes.QUOTED_STRING) {
-                    String filename = tl.get(ii + 1).getValue();
+                    filename = tl.get(ii + 1).getValue();
                     filename = filename.substring(1, filename.length() - 1); // get rid of quotes
                     // Handle either absolute or relative pathname for .include file
                     if (!new File(filename).isAbsolute()) {
                         filename = new File(program.getFilename()).getParent() + File.separator + filename;
                     }
+                    /*
                     if (inclFiles.containsKey(filename)) {
                         // This is a recursive include.  Generate error message and return immediately.
                         Token t = tl.get(ii + 1);
@@ -120,7 +128,7 @@ public class Tokenizer {
                                 "Recursive include of file " + filename));
                         throw new AssemblyException(errors);
                     }
-                    inclFiles.put(filename, filename);
+                    */
                     RISCVprogram incl = new RISCVprogram();
                     try {
                         incl.readSource(filename);
@@ -131,7 +139,7 @@ public class Tokenizer {
                         throw new AssemblyException(errors);
                     }
                     ArrayList<SourceLine> allLines = processIncludes(incl, inclFiles);
-                    result.addAll(allLines);
+                    //result.addAll(allLines);
                     hasInclude = true;
                     break;
                 }


### PR DESCRIPTION
This is a QoL change. Before, one had to either open all files in the project (e.g., printf.s, printnum.s printstr.s to be able to run bottles.s) or had to declare all files in the command line like so: java -jar rars.jar bottles.s printf.s printnum.s printstr.s.
Doing a .include wouldn't fix this because includes used to just inline the whole file. This would lead to .text, .data, etc, conflicts which was a mess. Note, the problem wasn't something like declaring a variable twice, but was actually like declaring .text twice. The typical C, C++ pre-processors don't have these kinds of conflicts. We are also using this in an educational context and this was a pain.
This PR changes it so that .include does the same as if you had the included files open (in the IDE) or had given them to as command line arguments. It's probably a bit hacky. Hope it's helpful.

The assembleString path did not have these changes, meaning this PR would deprecate it (it leaves it with the previous behavior).